### PR TITLE
Refactoring GooglePlacesAPIAdapter to GooglePlacesAdapter

### DIFF
--- a/src/main/java/src/application/controller/PlaceController.java
+++ b/src/main/java/src/application/controller/PlaceController.java
@@ -76,7 +76,7 @@ public class PlaceController {
 
         var nearbyPlacesResponse = new NearbyPlacesResponse(placeResponses, nearbyPlaces.getNextTokenPage());
 
-        logger.info("PLACE CONTROLLER - GET NEARBY PLACES FINISH - Places Response: {}", nearbyPlacesResponse);
+        logger.info("PLACE CONTROLLER - GET NEARBY PLACES FINISH - Nearby Places Response: {}", nearbyPlacesResponse);
 
         return ResponseEntity.ok(nearbyPlacesResponse);
 

--- a/src/main/java/src/application/controller/PlaceController.java
+++ b/src/main/java/src/application/controller/PlaceController.java
@@ -38,7 +38,7 @@ public class PlaceController {
 
     @Operation(summary = "Get 20 nearby Places per time")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Getting 20 Nearby Places ", content = @Content(schema = @Schema(implementation = PlaceResponse.class))),
+            @ApiResponse(responseCode = "200", description = "Getting 20 Nearby Places ", content = @Content(schema = @Schema(implementation = NearbyPlacesResponse.class))),
             @ApiResponse(responseCode = "204", description = "error.places.api.nearby.places.zero.results.message", content = @Content(schema = @Schema(implementation = StandardError.class))),
             @ApiResponse(responseCode = "403", description = "error.places.api.request.denied.message", content = @Content(schema = @Schema(implementation = StandardError.class))),
             @ApiResponse(responseCode = "422", description = "error.places.api.details.invalid.request.message", content = @Content(schema = @Schema(implementation = StandardError.class))),

--- a/src/main/java/src/domain/adapters/GooglePlacesAdapter.java
+++ b/src/main/java/src/domain/adapters/GooglePlacesAdapter.java
@@ -3,7 +3,6 @@ package src.domain.adapters;
 import com.google.maps.model.LatLng;
 import com.google.maps.model.PlaceDetails;
 import com.google.maps.model.PlaceType;
-import com.google.maps.model.PlacesSearchResponse;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +16,6 @@ import src.domain.ports.GooglePlacesPort;
 import src.infrastructure.agents.PlacesApiClient;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 

--- a/src/main/java/src/domain/adapters/GooglePlacesAdapter.java
+++ b/src/main/java/src/domain/adapters/GooglePlacesAdapter.java
@@ -57,17 +57,17 @@ public class GooglePlacesAdapter implements GooglePlacesPort {
     }
 
     @Override
-    public PlaceDetails getPlaceDetails(
-            String placeId
-    ) {
+    public Place getPlaceDetails(String placeId) {
 
         logger.info("GOOGLE PLACES API ADAPTER - GET PLACE DETAILS - Place Id: {}", placeId);
 
         var response = placesApiClient.getPlaceDetails(placeId);
 
-        logger.info("GOOGLE PLACES API ADAPTER - FINISH GET PLACE DETAILS - Place Id: {}", response);
+        var place = Place.toPlaceDetails(response);
 
-        return response;
+        logger.info("GOOGLE PLACES API ADAPTER - FINISH GET PLACE DETAILS - Place: {}", place);
+
+        return place;
 
     }
 

--- a/src/main/java/src/domain/exception/googlePlaces/OverQueryLimitApiClientException.java
+++ b/src/main/java/src/domain/exception/googlePlaces/OverQueryLimitApiClientException.java
@@ -10,4 +10,10 @@ public class OverQueryLimitApiClientException extends RuntimeException {
 
     }
 
+    public OverQueryLimitApiClientException() {
+
+        super(defaultMessage);
+
+    }
+
 }

--- a/src/main/java/src/domain/exception/googlePlaces/PlaceDetailsInvalidRequestApiClientException.java
+++ b/src/main/java/src/domain/exception/googlePlaces/PlaceDetailsInvalidRequestApiClientException.java
@@ -10,4 +10,10 @@ public class PlaceDetailsInvalidRequestApiClientException extends RuntimeExcepti
 
     }
 
+    public PlaceDetailsInvalidRequestApiClientException() {
+
+        super(defaultMessage);
+
+    }
+
 }

--- a/src/main/java/src/domain/exception/googlePlaces/PlaceDetailsNotFoundApiClientException.java
+++ b/src/main/java/src/domain/exception/googlePlaces/PlaceDetailsNotFoundApiClientException.java
@@ -10,4 +10,10 @@ public class PlaceDetailsNotFoundApiClientException extends RuntimeException {
 
     }
 
+    public PlaceDetailsNotFoundApiClientException() {
+
+        super(defaultMessage);
+
+    }
+
 }

--- a/src/main/java/src/domain/exception/googlePlaces/PlaceDetailsZeroResultsApiClientException.java
+++ b/src/main/java/src/domain/exception/googlePlaces/PlaceDetailsZeroResultsApiClientException.java
@@ -10,4 +10,10 @@ public class PlaceDetailsZeroResultsApiClientException extends RuntimeException 
 
     }
 
+    public PlaceDetailsZeroResultsApiClientException() {
+
+        super(defaultMessage);
+
+    }
+
 }

--- a/src/main/java/src/domain/exception/googlePlaces/RequestDeniedApiClientException.java
+++ b/src/main/java/src/domain/exception/googlePlaces/RequestDeniedApiClientException.java
@@ -10,4 +10,10 @@ public class RequestDeniedApiClientException extends RuntimeException {
 
     }
 
+    public RequestDeniedApiClientException() {
+
+        super(defaultMessage);
+
+    }
+
 }

--- a/src/main/java/src/domain/mocks/GooglePlacesAdapterMock.java
+++ b/src/main/java/src/domain/mocks/GooglePlacesAdapterMock.java
@@ -6,16 +6,21 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import src.domain.entity.Coordinates;
-import src.domain.ports.PlacesApiPort;
+import src.domain.entity.NearbyPlaces;
+import src.domain.entity.Place;
+import src.domain.ports.GooglePlacesPort;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 @Component
 @ConditionalOnProperty(name = "services.mock.enable", havingValue = "true")
-public class GooglePlacesAPIAdapterMock implements PlacesApiPort {
+public class GooglePlacesAdapterMock implements GooglePlacesPort {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Override
-    public PlacesSearchResponse getNearbyPlaces(
+    public NearbyPlaces getNearbyPlaces(
             Coordinates coordinates,
             Integer radius,
             String placeType,
@@ -85,9 +90,15 @@ public class GooglePlacesAPIAdapterMock implements PlacesApiPort {
         placesSearchResponse.results = new PlacesSearchResult[]{result1, result2, result3, result4};
         placesSearchResponse.nextPageToken = "3ee92b07-1305-4d1c-b5bb-b9283e9b1337";
 
-        logger.info("GOOGLE PLACES API ADAPTER MOCK - FINISH NEARBY SEARCH MOCKED - Places: {}", placesSearchResponse);
+        var places = Arrays.stream(placesSearchResponse.results)
+                .map(Place::toNearbyPlace)
+                .collect(Collectors.toList());
 
-        return placesSearchResponse;
+        var nearbyPlaces = new NearbyPlaces(places, placesSearchResponse.nextPageToken);
+
+        logger.info("GOOGLE PLACES API ADAPTER MOCK - FINISH NEARBY SEARCH MOCKED - Nearby Places: {}", nearbyPlaces);
+
+        return nearbyPlaces;
 
     }
 

--- a/src/main/java/src/domain/mocks/GooglePlacesAdapterMock.java
+++ b/src/main/java/src/domain/mocks/GooglePlacesAdapterMock.java
@@ -103,8 +103,49 @@ public class GooglePlacesAdapterMock implements GooglePlacesPort {
     }
 
     @Override
-    public PlaceDetails getPlaceDetails(String placeId) {
-        return null; // TODO implementar mock
+    public Place getPlaceDetails(String placeId) {
+
+        PlaceDetails details = new PlaceDetails();
+
+        details.addressComponents = new AddressComponent[]{new AddressComponent()};
+        details.adrAddress = "Adr Address";
+        details.businessStatus = "OPERATIONAL";
+        details.curbsidePickup = true;
+        details.currentOpeningHours = new OpeningHours();
+        details.delivery = true;
+        details.dineIn = true;
+        details.editorialSummary = new PlaceEditorialSummary();
+        details.formattedAddress = "Formatted Address";
+        details.formattedPhoneNumber = "123-456-7890";
+        details.geometry = new Geometry();
+        details.internationalPhoneNumber = "+1 123-456-7890";
+        details.name = "Random Place";
+        details.openingHours = new OpeningHours();
+        details.photos = new Photo[]{new Photo()};
+        details.placeId = "random_place_id";
+        details.plusCode = new PlusCode();
+        details.priceLevel = PriceLevel.MODERATE;
+        details.rating = 4.5f;
+        details.reservable = true;
+        details.reviews = new PlaceDetails.Review[]{new PlaceDetails.Review()};
+        details.secondaryOpeningHours = new OpeningHours();
+        details.servesBeer = true;
+        details.servesBreakfast = true;
+        details.servesBrunch = true;
+        details.servesDinner = true;
+        details.servesLunch = true;
+        details.servesVegetarianFood = true;
+        details.servesWine = true;
+        details.takeout = true;
+        details.types = new AddressType[]{AddressType.LODGING, AddressType.POINT_OF_INTEREST, AddressType.ESTABLISHMENT};
+        details.userRatingsTotal = 100;
+        details.utcOffset = -180;
+        details.vicinity = "Random Vicinity";
+        details.wheelchairAccessibleEntrance = true;
+        details.htmlAttributions = new String[]{"attribution1", "attribution2"};
+
+        return Place.toPlaceDetails(details);
+
     }
 
     @Override

--- a/src/main/java/src/domain/ports/GooglePlacesPort.java
+++ b/src/main/java/src/domain/ports/GooglePlacesPort.java
@@ -1,12 +1,12 @@
 package src.domain.ports;
 
 import com.google.maps.model.PlaceDetails;
-import com.google.maps.model.PlacesSearchResponse;
 import src.domain.entity.Coordinates;
+import src.domain.entity.NearbyPlaces;
 
-public interface PlacesApiPort {
+public interface GooglePlacesPort {
 
-    PlacesSearchResponse getNearbyPlaces(
+    NearbyPlaces getNearbyPlaces(
             Coordinates coordinates,
             Integer radius,
             String placeType,

--- a/src/main/java/src/domain/ports/GooglePlacesPort.java
+++ b/src/main/java/src/domain/ports/GooglePlacesPort.java
@@ -3,6 +3,7 @@ package src.domain.ports;
 import com.google.maps.model.PlaceDetails;
 import src.domain.entity.Coordinates;
 import src.domain.entity.NearbyPlaces;
+import src.domain.entity.Place;
 
 public interface GooglePlacesPort {
 
@@ -13,9 +14,7 @@ public interface GooglePlacesPort {
             String nextPageToken
     );
 
-    PlaceDetails getPlaceDetails(
-            String placeId
-    );
+    Place getPlaceDetails(String placeId);
 
     PlaceDetails getPlaceFromText(
             String placeName,

--- a/src/main/java/src/domain/service/GetNearbyPlacesService.java
+++ b/src/main/java/src/domain/service/GetNearbyPlacesService.java
@@ -6,12 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import src.domain.entity.Coordinates;
 import src.domain.entity.NearbyPlaces;
-import src.domain.entity.Place;
-import src.domain.ports.PlacesApiPort;
+import src.domain.ports.GooglePlacesPort;
 import src.domain.usecase.GetNearbyPlacesUseCase;
-
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 @Service
 public class GetNearbyPlacesService implements GetNearbyPlacesUseCase {
@@ -19,7 +15,7 @@ public class GetNearbyPlacesService implements GetNearbyPlacesUseCase {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
-    PlacesApiPort placesApiPort;
+    GooglePlacesPort googlePlacesPort;
 
     @Override
     public NearbyPlaces getNearbyPlaces(
@@ -31,16 +27,9 @@ public class GetNearbyPlacesService implements GetNearbyPlacesUseCase {
 
         logger.info("GET NEARBY PLACES SERVICE - GET NEARBY PLACES START - Coordinates: {}, Radius: {}, PlaceType: {}", coordinates, radius, placeType);
 
-        var placesSearchResponse = placesApiPort.getNearbyPlaces(coordinates, radius, placeType, nextPageToken);
+        var nearbyPlaces = googlePlacesPort.getNearbyPlaces(coordinates, radius, placeType, nextPageToken);
 
-        var placesEntities = Arrays
-                .stream(placesSearchResponse.results)
-                .map(Place::toNearbyPlace)
-                .collect(Collectors.toList());
-
-        var nearbyPlaces = new NearbyPlaces(placesEntities, placesSearchResponse.nextPageToken);
-
-        logger.info("GET NEARBY PLACES SERVICE - GET NEARBY PLACES FINISH - Places: {}", nearbyPlaces);
+        logger.info("GET NEARBY PLACES SERVICE - GET NEARBY PLACES FINISH - Nearby Places: {}", nearbyPlaces);
 
         return nearbyPlaces;
 

--- a/src/main/java/src/domain/service/GetPlaceDetailsService.java
+++ b/src/main/java/src/domain/service/GetPlaceDetailsService.java
@@ -23,13 +23,11 @@ public class GetPlaceDetailsService implements GetPlaceDetailsUseCase {
 
         logger.info("GET PLACES DETAILS SERVICE - GET PLACE DETAILS START - Place Id: {}", placeId);
 
-        var placeDetailsGoogle = googlePlacesPort.getPlaceDetails(placeId);
+        var place = googlePlacesPort.getPlaceDetails(placeId);
 
-        var placeDetails = Place.toPlaceDetails(placeDetailsGoogle);
+        logger.info("GET PLACES DETAILS SERVICE - GET PLACE DETAILS FINISH - Place Details: {}", place);
 
-        logger.info("GET PLACES DETAILS SERVICE - GET PLACE DETAILS FINISH - Place Details: {}", placeDetails);
-
-        return placeDetails;
+        return place;
 
     }
 

--- a/src/main/java/src/domain/service/GetPlaceDetailsService.java
+++ b/src/main/java/src/domain/service/GetPlaceDetailsService.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import src.domain.entity.Place;
-import src.domain.ports.PlacesApiPort;
+import src.domain.ports.GooglePlacesPort;
 import src.domain.usecase.GetPlaceDetailsUseCase;
 
 @Service
@@ -14,7 +14,7 @@ public class GetPlaceDetailsService implements GetPlaceDetailsUseCase {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
-    PlacesApiPort placesApiPort;
+    GooglePlacesPort googlePlacesPort;
 
     @Override
     public Place getPlaceDetails(
@@ -23,7 +23,7 @@ public class GetPlaceDetailsService implements GetPlaceDetailsUseCase {
 
         logger.info("GET PLACES DETAILS SERVICE - GET PLACE DETAILS START - Place Id: {}", placeId);
 
-        var placeDetailsGoogle = placesApiPort.getPlaceDetails(placeId);
+        var placeDetailsGoogle = googlePlacesPort.getPlaceDetails(placeId);
 
         var placeDetails = Place.toPlaceDetails(placeDetailsGoogle);
 

--- a/src/test/java/src/domain/service/GetPlaceDetailsServiceTest.java
+++ b/src/test/java/src/domain/service/GetPlaceDetailsServiceTest.java
@@ -7,13 +7,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import src.domain.entity.Place;
+import src.domain.exception.googlePlaces.*;
 import src.domain.ports.GooglePlacesPort;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 
 @ExtendWith(MockitoExtension.class)
 class GetPlaceDetailsServiceTest {
@@ -40,6 +41,138 @@ class GetPlaceDetailsServiceTest {
         // validation
         assertNotNull(placeDetails);
         assertEquals(expectedPlaceDetails, placeDetails);
+
+    }
+
+    @Test
+    @DisplayName("Should throw PlaceDetailsZeroResultsApiClientException when GooglePlacePort returns zero results")
+    void shouldThrowPlaceDetailsZeroResultsApiClientExceptionWhenGooglePlacePortReturnsZeroResults() {
+
+        // scenario
+        var placeId = "ChIJQXQEc04yGZURHsEanxBefFw";
+
+        var expectedException = new PlaceDetailsZeroResultsApiClientException();
+        doThrow(expectedException).when(googlePlacesPort).getPlaceDetails(placeId);
+
+        // action
+        var raisedException = assertThrows(PlaceDetailsZeroResultsApiClientException.class, () ->
+                service.getPlaceDetails(placeId)
+        );
+
+        // validation
+        assertNotNull(raisedException);
+        assertEquals(raisedException.getClass(), expectedException.getClass());
+        assertEquals(raisedException.getMessage(), expectedException.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("Should throw PlaceDetailsNotFoundApiClientException when GooglePlacePort returns not found")
+    void shouldThrowPlaceDetailsNotFoundApiClientExceptionWhenGooglePlacePortReturnsNotFound() {
+
+        // scenario
+        var placeId = "ChIJQXQEc04yGZURHsEanxBefFw";
+
+        var expectedException = new PlaceDetailsNotFoundApiClientException();
+        doThrow(expectedException).when(googlePlacesPort).getPlaceDetails(placeId);
+
+        // action
+        var raisedException = assertThrows(PlaceDetailsNotFoundApiClientException.class, () ->
+                service.getPlaceDetails(placeId)
+        );
+
+        // validation
+        assertNotNull(raisedException);
+        assertEquals(raisedException.getClass(), expectedException.getClass());
+        assertEquals(raisedException.getMessage(), expectedException.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("Should throw PlaceDetailsInvalidRequestApiClientException when GooglePlacePort returns invalid request")
+    void shouldThrowPlaceDetailsInvalidRequestApiClientExceptionWhenGooglePlacePortReturnsInvalidRequest() {
+
+        // scenario
+        var placeId = "ChIJQXQEc04yGZURHsEanxBefFw";
+
+        var expectedException = new PlaceDetailsInvalidRequestApiClientException();
+        doThrow(expectedException).when(googlePlacesPort).getPlaceDetails(placeId);
+
+        // action
+        var raisedException = assertThrows(PlaceDetailsInvalidRequestApiClientException.class, () ->
+                service.getPlaceDetails(placeId)
+        );
+
+        // validation
+        assertNotNull(raisedException);
+        assertEquals(raisedException.getClass(), expectedException.getClass());
+        assertEquals(raisedException.getMessage(), expectedException.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("Should throw OverQueryLimitApiClientException when GooglePlacePort returns Over Query Limit")
+    void shouldThrowOverQueryLimitApiClientExceptionWhenGooglePlacePortReturnsOverQueryLimit() {
+
+        // scenario
+        var placeId = "ChIJQXQEc04yGZURHsEanxBefFw";
+
+        var expectedException = new OverQueryLimitApiClientException();
+        doThrow(expectedException).when(googlePlacesPort).getPlaceDetails(placeId);
+
+        // action
+        var raisedException = assertThrows(OverQueryLimitApiClientException.class, () ->
+                service.getPlaceDetails(placeId)
+        );
+
+        // validation
+        assertNotNull(raisedException);
+        assertEquals(raisedException.getClass(), expectedException.getClass());
+        assertEquals(raisedException.getMessage(), expectedException.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("Should throw RequestDeniedApiClientException when GooglePlacePort returns Request Denied")
+    void shouldThrowRequestDeniedApiClientExceptionWhenGooglePlacePortReturnsOverQueryLimit() {
+
+        // scenario
+        var placeId = "ChIJQXQEc04yGZURHsEanxBefFw";
+
+        var expectedException = new RequestDeniedApiClientException();
+        doThrow(expectedException).when(googlePlacesPort).getPlaceDetails(placeId);
+
+        // action
+        var raisedException = assertThrows(RequestDeniedApiClientException.class, () ->
+                service.getPlaceDetails(placeId)
+        );
+
+        // validation
+        assertNotNull(raisedException);
+        assertEquals(raisedException.getClass(), expectedException.getClass());
+        assertEquals(raisedException.getMessage(), expectedException.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("Should throw PlacesApiClientException when GooglePlacePort returns Unexpect Error")
+    void shouldThrowPlacesApiClientExceptionWhenGooglePlacePortReturnsUnexpectError() {
+
+        // scenario
+        var placeId = "ChIJQXQEc04yGZURHsEanxBefFw";
+
+        var expectedException = new PlacesApiClientException("Unexpected Error");
+        doThrow(expectedException).when(googlePlacesPort).getPlaceDetails(placeId);
+
+        // action
+        var raisedException = assertThrows(PlacesApiClientException.class, () ->
+                service.getPlaceDetails(placeId)
+        );
+
+        // validation
+        assertNotNull(raisedException);
+        assertEquals(raisedException.getClass(), expectedException.getClass());
+        assertEquals(raisedException.getMessage(), expectedException.getMessage());
 
     }
 

--- a/src/test/java/src/domain/service/GetPlaceDetailsServiceTest.java
+++ b/src/test/java/src/domain/service/GetPlaceDetailsServiceTest.java
@@ -1,0 +1,66 @@
+package src.domain.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import src.domain.entity.Place;
+import src.domain.ports.GooglePlacesPort;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class GetPlaceDetailsServiceTest {
+
+    @Mock
+    GooglePlacesPort googlePlacesPort;
+
+    @InjectMocks
+    GetPlaceDetailsService service;
+
+    @Test
+    @DisplayName("Must to Get Place Details given a placeId")
+    void mustToGetPlaceDetailsGivenAPlaceId() {
+
+        // scenario
+        var placeId = "ChIJQXQEc04yGZURHsEanxBefFw";
+
+        var expectedPlaceDetails = createPlaceDetails(placeId);
+        doReturn(expectedPlaceDetails).when(googlePlacesPort).getPlaceDetails(placeId);
+
+        // action
+        Place placeDetails = service.getPlaceDetails(placeId);
+
+        // validation
+        assertNotNull(placeDetails);
+        assertEquals(expectedPlaceDetails, placeDetails);
+
+    }
+
+    private Place createPlaceDetails(String placeId) {
+
+        return Place
+                .builder()
+                .id(null)
+                .googlePlaceId(placeId)
+                .name("Restaurant Fictício")
+                .about(List.of("This is a Brazilian Restaurant"))
+                .contact("123456789")
+                .businessHours(null)
+                .rating(4.5f)
+                .isSaved(false)
+                .photoReference("photo_reference_1")
+                .images(List.of("photo_reference_1"))
+                .address("123 Rua Fictícia, Cidade Fictícia")
+                .distanceOfLocal(0.0f)
+                .build();
+
+    }
+
+}


### PR DESCRIPTION
### What?
A Classe GooglePlacesAPIAdapter estava no pacote application, no contexto de camadas, esse local era incorreto e estava gerando complexidade desnecessária.

Foi feita a refatoração para aloca-lá no pacote domain, além disso, a classa passou a se chamar GooglePlacesAdapter, os retornos dela foram refatorados para retornar as classes de dominio da aplicação.

Além disso, foram feitos testes unitários para a funcionalidade de GetPlaceDetails que não existiam.

### Why?
Para a utilização da classe GooglePlacesAPIAdapter fique mais simples para os desenvolvedores e a classe fique em conformidade com a estrutura do projeto

### How?
A classe GooglePlacesAPIAdapter mudou de nome e pacote, agora chama-se GooglePlacesAdapter e está dentro do pacote domain.adapters na aplicação.

### Testing?
GetPlaceDetailsService - 100%
GooglePlaceAdapter - 0% (Preciso aprender a mockar os retornos do Google, é complexo)

### Screenshots (optional)
  
### Anything Else?
